### PR TITLE
Fixes race conditions/out of order messages.

### DIFF
--- a/main.go
+++ b/main.go
@@ -55,7 +55,7 @@ func main() {
 
 	<-stop // Wait for a termination signal
 
-	log.Println("\nShutting down the bot...")
+	log.Println("Shutting down the bot...")
 
 	waBot.Stop()
 	err = discordBot.Stop()


### PR DESCRIPTION
Addresses Issue #1 by adding a `sync.Mutex` around the [`PipeToDiscord`](https://github.com/GoUAE/Hummus/blob/fix/race-condition/internal/whatsapp/whatsapp.go#L37-L40) method fixing race conditions/out of order calls to the discord Webhook.